### PR TITLE
feat: read posts from EmDash in the Notes app (local-only)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -25,6 +25,34 @@ export default defineConfig({
         "react-dom/server": "react-dom/server.edge",
       },
     },
+    // Pre-bundle SSR deps for the Astro 6 + @astrojs/cloudflare 13 dev server.
+    // Two problems being worked around:
+    //  1. On-demand discovery restarts the SSR worker mid-request → 500s.
+    //  2. CJS deps (e.g. `debug`) reference top-level `module`, which the
+    //     workerd module runner doesn't define → "module is not defined".
+    //     Pre-bundling wraps them with esbuild's __commonJS shim.
+    ssr: {
+      optimizeDeps: {
+        include: [
+          "astro/zod",
+          "astro/env/runtime",
+          "astro/assets/services/noop",
+          "astro-seo",
+          "astro-icon/components",
+          "debug",
+          "@portabletext/to-html",
+          "emdash",
+          "emdash/db/sqlite",
+          "emdash/media/local-runtime",
+          "emdash/middleware",
+          "emdash/middleware/auth",
+          "emdash/middleware/redirect",
+          "emdash/middleware/request-context",
+          "emdash/middleware/setup",
+          "emdash/storage/local",
+        ],
+      },
+    },
   },
 
   env: {

--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,6 @@
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "tailwindcss": "^4.2.4",
-        "vite": "^7.3.2",
       },
       "devDependencies": {
         "@biomejs/biome": "2.3.11",
@@ -37,9 +36,6 @@
         "wrangler": "^4.83.0",
       },
     },
-  },
-  "overrides": {
-    "vite": "^7.3.2",
   },
   "packages": {
     "@antfu/install-pkg": ["@antfu/install-pkg@1.0.0", "", { "dependencies": { "package-manager-detector": "^0.2.8", "tinyexec": "^0.3.2" } }, "sha512-xvX6P/lo1B3ej0OsaErAjqgFYzYVcJpamjLAFLYh9vRJngBrMoUG7aVnrGTeqM7yxbyTD5p3F2+0/QUEh8Vzhw=="],
@@ -682,7 +678,7 @@
 
     "@types/nlcst": ["@types/nlcst@2.0.3", "", { "dependencies": { "@types/unist": "*" } }, "sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA=="],
 
-    "@types/node": ["@types/node@17.0.45", "", {}, "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw=="],
+    "@types/node": ["@types/node@24.12.0", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ=="],
 
     "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
 
@@ -2092,9 +2088,13 @@
 
     "@types/babel__traverse/@babel/types": ["@babel/types@7.26.9", "", { "dependencies": { "@babel/helper-string-parser": "^7.25.9", "@babel/helper-validator-identifier": "^7.25.9" } }, "sha512-Y3IR1cRnOxOCDvMmNiym7XpXQ93iGDDPHx+Zj+NM+rg0fBaShfQLkg+hKPaZCEvg5N/LeCo4+Rj/i3FuJsIQaw=="],
 
+    "@types/sax/@types/node": ["@types/node@17.0.45", "", {}, "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw=="],
+
+    "@types/tar/@types/node": ["@types/node@17.0.45", "", {}, "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw=="],
+
     "@types/tar/minipass": ["minipass@4.2.8", "", {}, "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ=="],
 
-    "@types/ws/@types/node": ["@types/node@24.12.0", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ=="],
+    "@types/yauzl/@types/node": ["@types/node@17.0.45", "", {}, "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw=="],
 
     "@vitejs/plugin-react/@babel/core": ["@babel/core@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-compilation-targets": "^7.28.6", "@babel/helper-module-transforms": "^7.28.6", "@babel/helpers": "^7.28.6", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/traverse": "^7.29.0", "@babel/types": "^7.29.0", "@jridgewell/remapping": "^2.3.5", "convert-source-map": "^2.0.0", "debug": "^4.1.0", "gensync": "^1.0.0-beta.2", "json5": "^2.2.3", "semver": "^6.3.1" } }, "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA=="],
 
@@ -2111,8 +2111,6 @@
     "astro-portabletext/@portabletext/types": ["@portabletext/types@2.0.15", "", {}, "sha512-2e6i2gSQsrA/5OL5Gm4/9bxB9MNO73Fa47zj+0mT93xkoQUCGCWX5fZh1YBJ86hszaRYlqvqG08oULxvvPPp/Q=="],
 
     "body-parser/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
-
-    "bun-types/@types/node": ["@types/node@24.12.0", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ=="],
 
     "call-bound/get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
 
@@ -2176,6 +2174,8 @@
 
     "prettier-plugin-astro/@astrojs/compiler": ["@astrojs/compiler@2.10.4", "", {}, "sha512-86B3QGagP99MvSNwuJGiYSBHnh8nLvm2Q1IFI15wIUJJsPeQTO3eb2uwBmrqRsXykeR/mBzH8XCgz5AAt1BJrQ=="],
 
+    "protobufjs/@types/node": ["@types/node@17.0.45", "", {}, "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw=="],
+
     "remark-smartypants/unist-util-visit": ["unist-util-visit@5.0.0", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg=="],
 
     "retext-smartypants/unist-util-visit": ["unist-util-visit@5.0.0", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg=="],
@@ -2191,8 +2191,6 @@
     "send/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "sharp/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
-
-    "sitemap/@types/node": ["@types/node@24.12.0", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ=="],
 
     "sitemap/sax": ["sax@1.4.1", "", {}, "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg=="],
 

--- a/package.json
+++ b/package.json
@@ -32,8 +32,7 @@
     "emdash": "^0.9.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
-    "tailwindcss": "^4.2.4",
-    "vite": "^7.3.2"
+    "tailwindcss": "^4.2.4"
   },
   "devDependencies": {
     "@biomejs/biome": "2.3.11",
@@ -46,8 +45,5 @@
     "ultracite": "7.0.12",
     "vite-plugin-svgr": "^5.2.0",
     "wrangler": "^4.83.0"
-  },
-  "overrides": {
-    "vite": "^7.3.2"
   }
 }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,61 +1,86 @@
 ---
-import { getCollection, render } from "astro:content";
 import Background from "@components/background.astro";
 import { DesktopManager } from "@components/desktop-manager";
 import Layout from "@layouts/layout.astro";
+import { toHTML } from "@portabletext/to-html";
 import type { ImageMetadata } from "astro";
+import { getAllTermsForEntries, getEmDashCollection } from "emdash";
 
-// Get all wallpapers using import.meta.glob
 const wallpaperModules = Object.values(
   import.meta.glob<{ default: ImageMetadata }>(
     "/src/assets/wallpapers/*.{jpeg,jpg,png,gif}"
   )
 );
 
-// Select and load random wallpaper
 const randomModule =
   wallpaperModules[Math.floor(Math.random() * wallpaperModules.length)];
 const { default: randomWallpaper } = await randomModule();
 
-// Get blog posts for Notes app
-const blogPosts = await getCollection("blog", ({ data }) => !data.draft);
+interface EmdashPostData {
+  title: string;
+  excerpt?: string;
+  body?: unknown;
+}
 
-// Sort by date descending
-const sortedPosts = blogPosts.sort(
-  (a, b) => b.data.date.getTime() - a.data.date.getTime()
-);
+interface EmdashPost {
+  id: string;
+  publishedAt?: Date | string | null;
+  data: EmdashPostData;
+}
 
-// Prepare posts metadata for client (content will be hydrated from hidden divs)
-const postsForClient = sortedPosts.map((post) => ({
-  slug: post.id,
-  title: post.data.title,
-  date: post.data.date.toISOString(),
-  preview: post.data.preview,
-  tags: post.data.tags,
-  content: "", // Will be hydrated client-side
-}));
+const { entries: rawEntries, error } = await getEmDashCollection("posts", {
+  status: "published",
+});
+
+if (error) {
+  console.error("[index] Failed to load posts from EmDash:", error);
+}
+
+const posts = [...(rawEntries as unknown as EmdashPost[])].sort((a, b) => {
+  return (
+    new Date(b.publishedAt ?? 0).getTime() -
+    new Date(a.publishedAt ?? 0).getTime()
+  );
+});
+
+const tagMap = posts.length
+  ? await getAllTermsForEntries(
+      "posts",
+      posts.map((p) => p.id)
+    )
+  : new Map();
+
+const postsForClient = posts.map((post) => {
+  const date =
+    post.publishedAt instanceof Date
+      ? post.publishedAt.toISOString()
+      : (post.publishedAt ?? "");
+  return {
+    slug: post.id,
+    title: post.data.title,
+    date,
+    preview: post.data.excerpt ?? "",
+    tags: (tagMap.get(post.id)?.tag ?? []).map(
+      (term: { slug: string }) => term.slug
+    ),
+    content: "",
+  };
+});
 ---
 
 <Layout backgroundImage={randomWallpaper.src}>
   <Background src={randomWallpaper} />
 
-  <!-- Render blog content to hidden divs for client-side hydration -->
   <div id="blog-content-store" class="hidden">
-    {sortedPosts.map(async (post) => {
-      const { Content } = await render(post);
-      return (
-        <div data-slug={post.id}>
-          <Content />
-        </div>
-      );
-    })}
+    {posts.map((post) => (
+      <div data-slug={post.id} set:html={toHTML((post.data.body ?? []) as Parameters<typeof toHTML>[0])} />
+    ))}
   </div>
 
   <DesktopManager client:load posts={postsForClient} />
 </Layout>
 
 <script>
-  // Hydrate blog content into the NotesApp after DOM is ready
   const hydrateContent = () => {
     const store = document.getElementById("blog-content-store");
     if (!store) {
@@ -70,7 +95,6 @@ const postsForClient = sortedPosts.map((post) => ({
       }
     }
 
-    // Dispatch event with content
     window.dispatchEvent(
       new CustomEvent("blog-content-loaded", {
         detail: contentMap,
@@ -78,7 +102,6 @@ const postsForClient = sortedPosts.map((post) => ({
     );
   };
 
-  // Run on load
   if (document.readyState === "loading") {
     document.addEventListener("DOMContentLoaded", hydrateContent);
   } else {


### PR DESCRIPTION
Closes #94. Part of #91. **Depends on #98** merging first; this PR currently targets `feat/emdash-phase-3` and will retarget to `feat/emdash-local` after #98 lands.

**This PR makes the branch non-mergeable to `main` on its own** — once `index.astro` reads from EmDash, the existing Cloudflare Pages deploy can't serve the site (no D1 / no EmDash runtime). That cutover is the follow-up plan.

## Summary

Rewrites `src/pages/index.astro` to source posts from EmDash:

- `getCollection("blog", ...)` → `getEmDashCollection("posts", { status: "published" })`
- Tags come from EmDash's tag taxonomy via `getAllTermsForEntries`
- Portable Text body rendered to HTML server-side with `@portabletext/to-html`'s `toHTML()`, emitted into the same hidden-`<div data-slug>` store that the existing client hydration script reads — preserves the React `DesktopManager` / `NotesApp` contract unchanged

`src/content/blog/*.md` and `src/content/config.ts` are intentionally **left in place** so `git revert` of this PR restores the markdown reads. Cleanup of the file-based collection belongs in the follow-up Cloudflare cutover plan, after production has flipped to EmDash.

## Dev server fix (second commit)

Adds `vite.ssr.optimizeDeps.include` to `astro.config.mjs`. Two bugs in the Astro 6 + @astrojs/cloudflare 13 dev pipeline were causing 500s once `index.astro` started pulling EmDash into the SSR module graph:

1. **`module is not defined`** — workerd's vite module runner doesn't define `module` as a global, so externalized CJS deps that reference top-level `module` blow up. Known offender: `debug` (transitive via `astro-icon`). Same bug class as Astro #16029 / #15284.
2. **`Promise will never complete` / `chunk does not exist`** — on-demand vite dep optimization restarts the SSR worker mid-request, miniflare holds a stale chunk URL, the chunk gets unlinked during reload, request never resolves.

Pre-bundling the listed deps wraps CJS in esbuild's `__commonJS` shim and avoids the on-demand discovery path. Verified locally: `/` returns 200 (redirects to `/_emdash/admin/setup` since the wizard hasn't been completed). Build is unaffected.

## Side cleanup

Removed the `overrides: { vite: "^7.3.2" }` block in `package.json` that Phase 1 added to dedupe vite and silence a `Plugin<any>` vs `PluginOption` TS error. With `vite-plugin-svgr@5.2.0` and `@tailwindcss/vite@4.2.4` in place — both publish types compatible with Astro 6's bundled vite — `bunx astro check` stays clean without the override.

## Verification

- [x] `bunx astro check` → 0 errors
- [x] `bun run build` succeeds
- [x] `bun run dev` boots cleanly; `/` returns 200 (302 → setup wizard) with the SSR pre-bundle fix

## Manual setup step (one-time)

After this PR merges + you check out the branch:
1. `bun install`
2. `bunx emdash init --database ./data.db`
3. `bunx emdash seed seeds/initial-posts.json --database ./data.db` (if not already done in #98)
4. `bun run scripts/import-posts.ts ./data.db` (to backdate `published_at`)
5. `bun run dev`
6. Visit `http://localhost:4321/_emdash/admin/setup` and complete the setup wizard (site title, admin email, register a passkey via Touch ID / Face ID / WebAuthn)
7. Visit `http://localhost:4321/` — Notes app now shows both posts sourced from EmDash

🤖 Generated with [Claude Code](https://claude.com/claude-code)