### PR TITLE
test: Add Vitest + Playwright baseline suite with CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,62 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GOOGLE_API_KEY: test-dummy-key
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      # The astro CLI runs under node; Astro requires a recent runtime.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.13
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Lint
+        run: bun run check
+
+      - name: Unit tests
+        run: bun run test:unit
+
+      - name: Build
+        run: bun run build
+
+      - name: Verify sitemap output
+        run: test -f dist/sitemap-index.xml
+
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+
+      - name: Install Playwright browsers
+        run: bunx playwright install --with-deps chromium
+
+      - name: End-to-end tests
+        run: bun run test:e2e
+
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ pnpm-debug.log*
 
 # wrangler
 .wrangler/
+
+# test artifacts
+test-results/
+playwright-report/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,16 +16,36 @@ A personal website built with Astro 5.x (SSR mode), React 19.x, TypeScript, and 
 | `bun run deploy` | Build and deploy to Cloudflare Pages |
 | `bun run check` | Lint check via Ultracite/Biome |
 | `bun run fix` | Auto-fix lint/format issues |
+| `bun run test` | Run unit and e2e suites |
+| `bun run test:unit` | Run Vitest unit tests |
+| `bun run test:unit:watch` | Run Vitest in watch mode |
+| `bun run test:e2e` | Run Playwright e2e tests (spawns its own dev server) |
 | `bun run clean` | Remove `./dist` and `./.astro` directories |
 | `bun run cf-typegen` | Generate Cloudflare Worker types |
 
 ### Testing
 
-No test suite is currently configured. The pre-commit hook runs `ultracite fix` only.
+- Unit tests live in `test/unit/` (Vitest via `getViteConfig`, so `astro:*`
+  virtual modules and tsconfig path aliases resolve). Middleware tests mock
+  `astro:env/server` and `astro:middleware` for determinism.
+- E2e tests live in `test/e2e/` (Playwright, chromium only). The config starts
+  `bun run dev` itself with `PLAYWRIGHT_TEST=1` (disables the Astro dev
+  toolbar, which otherwise intercepts dock clicks) and a raised rate-limit
+  window (every dev request shares the "unknown" client IP).
+- `test/fixtures/expected-posts.ts` is the blog content contract (slugs,
+  titles, ordering, headings, image prefixes). It must keep passing unchanged
+  through framework upgrades and content-system migrations.
+- E2e assertions are semantic (headings, alt text, counts) - never HTML
+  snapshots, so markdown-renderer internals can change without false alarms.
+- IMPORTANT: never run `bun test` - bun's built-in runner grabs `*.test.ts`
+  files but cannot handle `vi.mock`. Always use `bun run test:unit`.
 
 ### Running a Single Test
 
-Not applicable - no test files exist in this codebase.
+```sh
+bunx vitest run test/unit/cors.test.ts
+bunx playwright test test/e2e/notes.spec.ts
+```
 
 ## Code Style Guidelines
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -13,6 +13,11 @@ export default defineConfig({
   site: "https://edwardvaisman.ca",
   trailingSlash: "never",
 
+  // The dev toolbar overlays the dock and intercepts Playwright clicks.
+  devToolbar: {
+    enabled: !process.env.PLAYWRIGHT_TEST,
+  },
+
   vite: {
     plugins: [tailwindcss(), svgr({ include: "**/*.svg?react" })],
     resolve: {

--- a/bun.lock
+++ b/bun.lock
@@ -4,31 +4,34 @@
   "workspaces": {
     "": {
       "dependencies": {
-        "@astrojs/cloudflare": "^12.6.12",
+        "@astrojs/cloudflare": "^12.6.13",
         "@astrojs/react": "^4.4.2",
-        "@astrojs/sitemap": "^3.7.0",
+        "@astrojs/sitemap": "^3.7.1",
         "@fontsource-variable/dancing-script": "^5.2.8",
         "@fontsource/ibm-plex-mono": "^5.2.7",
         "@fontsource/ibm-plex-sans": "^5.2.8",
-        "@google/genai": "^1.38.0",
-        "@tailwindcss/vite": "^4.1.18",
-        "@types/react": "^19.2.9",
+        "@google/genai": "^1.44.0",
+        "@tailwindcss/vite": "^4.2.1",
+        "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
-        "astro": "^5.16.12",
+        "astro": "^5.18.1",
         "astro-icon": "^1.1.5",
         "astro-seo": "^0.8.4",
-        "react": "^19.2.3",
-        "react-dom": "^19.2.3",
-        "tailwindcss": "^4.1.18",
+        "react": "^19.2.4",
+        "react-dom": "^19.2.4",
+        "tailwindcss": "^4.2.1",
       },
       "devDependencies": {
         "@biomejs/biome": "2.3.11",
         "@iconify-json/mdi": "^1.2.3",
+        "@playwright/test": "^1.60.0",
         "@tailwindcss/typography": "^0.5.19",
+        "happy-dom": "^20.10.2",
         "husky": "^9.1.7",
         "ultracite": "7.0.12",
         "vite-plugin-svgr": "^4.5.0",
-        "wrangler": "^4.59.3",
+        "vitest": "^4.1.8",
+        "wrangler": "^4.72.0",
       },
     },
   },
@@ -303,6 +306,8 @@
 
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
 
+    "@playwright/test": ["@playwright/test@1.60.0", "", { "dependencies": { "playwright": "1.60.0" }, "bin": { "playwright": "cli.js" } }, "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag=="],
+
     "@poppinss/colors": ["@poppinss/colors@4.1.6", "", { "dependencies": { "kleur": "^4.1.5" } }, "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg=="],
 
     "@poppinss/dumper": ["@poppinss/dumper@0.6.5", "", { "dependencies": { "@poppinss/colors": "^4.1.5", "@sindresorhus/is": "^7.0.2", "supports-color": "^10.0.0" } }, "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw=="],
@@ -395,6 +400,8 @@
 
     "@speed-highlight/core": ["@speed-highlight/core@1.2.12", "", {}, "sha512-uilwrK0Ygyri5dToHYdZSjcvpS2ZwX0w5aSt3GCEN9hrjxWCoeV4Z2DTXuxjwbntaLQIEEAlCeNQss5SoHvAEA=="],
 
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
     "@svgr/babel-plugin-add-jsx-attribute": ["@svgr/babel-plugin-add-jsx-attribute@8.0.0", "", { "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-b9MIk7yhdS1pMCZM8VeNfUlSKVRhsHZNMl5O9SfaX0l0t5wjdgu4IDzGB8bpnGBBOjGST3rRFVsaaEtI4W6f7g=="],
 
     "@svgr/babel-plugin-remove-jsx-attribute": ["@svgr/babel-plugin-remove-jsx-attribute@8.0.0", "", { "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-BcCkm/STipKvbCl6b7QFrMh/vx00vIP63k2eM66MfHJzPr6O2U0jYEViXkHJWqXqQYjdeA9cuCl5KWmlwjDvbA=="],
@@ -463,7 +470,11 @@
 
     "@types/babel__traverse": ["@types/babel__traverse@7.20.6", "", { "dependencies": { "@babel/types": "^7.20.7" } }, "sha512-r1bzfrm0tomOI8g1SzvCaQHo6Lcv6zu0EA+W2kHrt8dyrHQxGzBBL4kdkzIS+jBMV+EYcMAEAqXqYaLJq5rOZg=="],
 
+    "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
+
     "@types/debug": ["@types/debug@4.1.12", "", { "dependencies": { "@types/ms": "*" } }, "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ=="],
+
+    "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
 
     "@types/estree": ["@types/estree@1.0.6", "", {}, "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw=="],
 
@@ -475,7 +486,7 @@
 
     "@types/nlcst": ["@types/nlcst@2.0.3", "", { "dependencies": { "@types/unist": "*" } }, "sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA=="],
 
-    "@types/node": ["@types/node@17.0.45", "", {}, "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw=="],
+    "@types/node": ["@types/node@24.12.0", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ=="],
 
     "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
 
@@ -489,11 +500,29 @@
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
+    "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="],
+
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
+
     "@types/yauzl": ["@types/yauzl@2.10.3", "", { "dependencies": { "@types/node": "*" } }, "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q=="],
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@4.7.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.27", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA=="],
+
+    "@vitest/expect": ["@vitest/expect@4.1.8", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.8", "@vitest/utils": "4.1.8", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ=="],
+
+    "@vitest/mocker": ["@vitest/mocker@4.1.8", "", { "dependencies": { "@vitest/spy": "4.1.8", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw=="],
+
+    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.8", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA=="],
+
+    "@vitest/runner": ["@vitest/runner@4.1.8", "", { "dependencies": { "@vitest/utils": "4.1.8", "pathe": "^2.0.3" } }, "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg=="],
+
+    "@vitest/snapshot": ["@vitest/snapshot@4.1.8", "", { "dependencies": { "@vitest/pretty-format": "4.1.8", "@vitest/utils": "4.1.8", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ=="],
+
+    "@vitest/spy": ["@vitest/spy@4.1.8", "", {}, "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA=="],
+
+    "@vitest/utils": ["@vitest/utils@4.1.8", "", { "dependencies": { "@vitest/pretty-format": "4.1.8", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg=="],
 
     "@volar/kit": ["@volar/kit@2.4.11", "", { "dependencies": { "@volar/language-service": "2.4.11", "@volar/typescript": "2.4.11", "typesafe-path": "^0.2.2", "vscode-languageserver-textdocument": "^1.0.11", "vscode-uri": "^3.0.8" }, "peerDependencies": { "typescript": "*" } }, "sha512-ups5RKbMzMCr6RKafcCqDRnJhJDNWqo2vfekwOAj6psZ15v5TlcQFQAyokQJ3wZxVkzxrQM+TqTRDENfQEXpmA=="],
 
@@ -532,6 +561,8 @@
     "aria-query": ["aria-query@5.3.2", "", {}, "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw=="],
 
     "array-iterate": ["array-iterate@2.0.1", "", {}, "sha512-I1jXZMjAgCMmxT4qxXfPXa6SthSoE8h6gkSI9BGGNv8mP8G/v0blc+qFnZu6K42vTOiuME596QaLO0TP3Lk0xg=="],
+
+    "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
 
     "astro": ["astro@5.18.1", "", { "dependencies": { "@astrojs/compiler": "^2.13.0", "@astrojs/internal-helpers": "0.7.6", "@astrojs/markdown-remark": "6.3.11", "@astrojs/telemetry": "3.3.0", "@capsizecss/unpack": "^4.0.0", "@oslojs/encoding": "^1.1.0", "@rollup/pluginutils": "^5.3.0", "acorn": "^8.15.0", "aria-query": "^5.3.2", "axobject-query": "^4.1.0", "boxen": "8.0.1", "ci-info": "^4.3.1", "clsx": "^2.1.1", "common-ancestor-path": "^1.0.1", "cookie": "^1.1.1", "cssesc": "^3.0.0", "debug": "^4.4.3", "deterministic-object-hash": "^2.0.2", "devalue": "^5.6.2", "diff": "^8.0.3", "dlv": "^1.1.3", "dset": "^3.1.4", "es-module-lexer": "^1.7.0", "esbuild": "^0.27.3", "estree-walker": "^3.0.3", "flattie": "^1.1.1", "fontace": "~0.4.0", "github-slugger": "^2.0.0", "html-escaper": "3.0.3", "http-cache-semantics": "^4.2.0", "import-meta-resolve": "^4.2.0", "js-yaml": "^4.1.1", "magic-string": "^0.30.21", "magicast": "^0.5.1", "mrmime": "^2.0.1", "neotraverse": "^0.6.18", "p-limit": "^6.2.0", "p-queue": "^8.1.1", "package-manager-detector": "^1.6.0", "piccolore": "^0.1.3", "picomatch": "^4.0.3", "prompts": "^2.4.2", "rehype": "^13.0.2", "semver": "^7.7.3", "shiki": "^3.21.0", "smol-toml": "^1.6.0", "svgo": "^4.0.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tsconfck": "^3.1.6", "ultrahtml": "^1.6.0", "unifont": "~0.7.3", "unist-util-visit": "^5.0.0", "unstorage": "^1.17.4", "vfile": "^6.0.3", "vite": "^6.4.1", "vitefu": "^1.1.1", "xxhash-wasm": "^1.1.0", "yargs-parser": "^21.1.1", "yocto-spinner": "^0.2.3", "zod": "^3.25.76", "zod-to-json-schema": "^3.25.1", "zod-to-ts": "^1.2.0" }, "optionalDependencies": { "sharp": "^0.34.0" }, "bin": { "astro": "astro.js" } }, "sha512-m4VWilWZ+Xt6NPoYzC4CgGZim/zQUO7WFL0RHCH0AiEavF1153iC3+me2atDvXpf/yX4PyGUeD8wZLq1cirT3g=="],
 
@@ -573,6 +604,8 @@
 
     "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
 
+    "buffer-image-size": ["buffer-image-size@0.6.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ=="],
+
     "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
 
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
@@ -582,6 +615,8 @@
     "caniuse-lite": ["caniuse-lite@1.0.30001699", "", {}, "sha512-b+uH5BakXZ9Do9iK+CkDmctUSEqZl+SP056vc5usa0PL+ev5OHw003rZXcnjNDv3L8P5j6rwT6C0BPKSikW08w=="],
 
     "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
+
+    "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
 
     "chalk": ["chalk@5.4.1", "", {}, "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w=="],
 
@@ -705,7 +740,7 @@
 
     "enhanced-resolve": ["enhanced-resolve@5.20.0", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.0" } }, "sha512-/ce7+jQ1PQ6rVXwe+jKEg5hW5ciicHwIQUagZkp6IufBoY3YDgdTTY1azVs0qoRgVmvsNB+rbjLJxDAeHHtwsQ=="],
 
-    "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+    "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
     "error-ex": ["error-ex@1.3.4", "", { "dependencies": { "is-arrayish": "^0.2.1" } }, "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ=="],
 
@@ -715,7 +750,7 @@
 
     "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
 
-    "es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
+    "es-module-lexer": ["es-module-lexer@2.1.0", "", {}, "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ=="],
 
     "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
 
@@ -730,6 +765,8 @@
     "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
     "eventemitter3": ["eventemitter3@5.0.1", "", {}, "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="],
+
+    "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
 
     "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
 
@@ -806,6 +843,8 @@
     "gtoken": ["gtoken@8.0.0", "", { "dependencies": { "gaxios": "^7.0.0", "jws": "^4.0.0" } }, "sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw=="],
 
     "h3": ["h3@1.15.5", "", { "dependencies": { "cookie-es": "^1.2.2", "crossws": "^0.3.5", "defu": "^6.1.4", "destr": "^2.0.5", "iron-webcrypto": "^1.2.1", "node-mock-http": "^1.0.4", "radix3": "^1.1.2", "ufo": "^1.6.3", "uncrypto": "^0.1.3" } }, "sha512-xEyq3rSl+dhGX2Lm0+eFQIAzlDN6Fs0EcC4f7BNUmzaRX/PTzeuM+Tr2lHB8FoXggsQIeXLj8EDVgs5ywxyxmg=="],
+
+    "happy-dom": ["happy-dom@20.10.2", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "buffer-image-size": "^0.6.4", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.21.0" } }, "sha512-5p9Sxis3eowDJKqx90QCsgbNA02XXqJ59NOHvD4V6cxp+rP4d/xOyVx7uY3hS8hiUbY1VeiFH8lbJ81AyuDVLQ=="],
 
     "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
 
@@ -1083,6 +1122,8 @@
 
     "nypm": ["nypm@0.6.4", "", { "dependencies": { "citty": "^0.2.0", "pathe": "^2.0.3", "tinyexec": "^1.0.2" }, "bin": { "nypm": "dist/cli.mjs" } }, "sha512-1TvCKjZyyklN+JJj2TS3P4uSQEInrM/HkkuSXsEzm1ApPgBffOn8gFguNnZf07r/1X6vlryfIqMUkJKQMzlZiw=="],
 
+    "obug": ["obug@2.1.2", "", {}, "sha512-AWGB9WFcRXOQs48Z/udjI5ZcZMHXwX8XPByNpOydgcGsDLIzjGizhoMWJyKAWze7AVW/2W1i+/gPX4YtKe5cyg=="],
+
     "ofetch": ["ofetch@1.5.1", "", { "dependencies": { "destr": "^2.0.5", "node-fetch-native": "^1.6.7", "ufo": "^1.6.1" } }, "sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA=="],
 
     "ohash": ["ohash@2.0.11", "", {}, "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ=="],
@@ -1138,6 +1179,10 @@
     "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 
     "pkg-types": ["pkg-types@1.3.1", "", { "dependencies": { "confbox": "^0.1.8", "mlly": "^1.7.4", "pathe": "^2.0.1" } }, "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ=="],
+
+    "playwright": ["playwright@1.60.0", "", { "dependencies": { "playwright-core": "1.60.0" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA=="],
+
+    "playwright-core": ["playwright-core@1.60.0", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA=="],
 
     "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
 
@@ -1243,6 +1288,8 @@
 
     "shiki": ["shiki@3.21.0", "", { "dependencies": { "@shikijs/core": "3.21.0", "@shikijs/engine-javascript": "3.21.0", "@shikijs/engine-oniguruma": "3.21.0", "@shikijs/langs": "3.21.0", "@shikijs/themes": "3.21.0", "@shikijs/types": "3.21.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-N65B/3bqL/TI2crrXr+4UivctrAGEjmsib5rPMMPpFp1xAx/w03v8WZ9RDDFYteXoEgY7qZ4HGgl5KBIu1153w=="],
 
+    "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
     "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
@@ -1256,6 +1303,10 @@
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
     "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
+
+    "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
+    "std-env": ["std-env@4.1.0", "", {}, "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ=="],
 
     "stream-replace-string": ["stream-replace-string@2.0.0", "", {}, "sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w=="],
 
@@ -1285,9 +1336,13 @@
 
     "tiny-inflate": ["tiny-inflate@1.0.3", "", {}, "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw=="],
 
+    "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+
     "tinyexec": ["tinyexec@1.0.2", "", {}, "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg=="],
 
     "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
+
+    "tinyrainbow": ["tinyrainbow@3.1.0", "", {}, "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
@@ -1363,6 +1418,8 @@
 
     "vitefu": ["vitefu@1.1.1", "", { "peerDependencies": { "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0-beta.0" }, "optionalPeers": ["vite"] }, "sha512-B/Fegf3i8zh0yFbpzZ21amWzHmuNlLlmJT6n7bu5e+pCHUKQIfXSYokrqOBGEMMe9UG2sostKQF9mml/vYaWJQ=="],
 
+    "vitest": ["vitest@4.1.8", "", { "dependencies": { "@vitest/expect": "4.1.8", "@vitest/mocker": "4.1.8", "@vitest/pretty-format": "4.1.8", "@vitest/runner": "4.1.8", "@vitest/snapshot": "4.1.8", "@vitest/spy": "4.1.8", "@vitest/utils": "4.1.8", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.8", "@vitest/browser-preview": "4.1.8", "@vitest/browser-webdriverio": "4.1.8", "@vitest/coverage-istanbul": "4.1.8", "@vitest/coverage-v8": "4.1.8", "@vitest/ui": "4.1.8", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig=="],
+
     "volar-service-css": ["volar-service-css@0.0.62", "", { "dependencies": { "vscode-css-languageservice": "^6.3.0", "vscode-languageserver-textdocument": "^1.0.11", "vscode-uri": "^3.0.8" }, "peerDependencies": { "@volar/language-service": "~2.4.0" }, "optionalPeers": ["@volar/language-service"] }, "sha512-JwNyKsH3F8PuzZYuqPf+2e+4CTU8YoyUHEHVnoXNlrLe7wy9U3biomZ56llN69Ris7TTy/+DEX41yVxQpM4qvg=="],
 
     "volar-service-emmet": ["volar-service-emmet@0.0.62", "", { "dependencies": { "@emmetio/css-parser": "^0.4.0", "@emmetio/html-matcher": "^1.3.0", "@vscode/emmet-helper": "^2.9.3", "vscode-uri": "^3.0.8" }, "peerDependencies": { "@volar/language-service": "~2.4.0" }, "optionalPeers": ["@volar/language-service"] }, "sha512-U4dxWDBWz7Pi4plpbXf4J4Z/ss6kBO3TYrACxWNsE29abu75QzVS0paxDDhI6bhqpbDFXlpsDhZ9aXVFpnfGRQ=="],
@@ -1403,11 +1460,13 @@
 
     "whatwg-encoding": ["whatwg-encoding@3.1.1", "", { "dependencies": { "iconv-lite": "0.6.3" } }, "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ=="],
 
-    "whatwg-mimetype": ["whatwg-mimetype@4.0.0", "", {}, "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg=="],
+    "whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
     "which-pm-runs": ["which-pm-runs@1.1.0", "", {}, "sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA=="],
+
+    "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
 
     "widest-line": ["widest-line@5.0.0", "", { "dependencies": { "string-width": "^7.0.0" } }, "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA=="],
 
@@ -1421,7 +1480,7 @@
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
-    "ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
+    "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
 
     "xxhash-wasm": ["xxhash-wasm@1.1.0", "", {}, "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA=="],
 
@@ -1483,6 +1542,8 @@
 
     "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
+    "@google/genai/ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
+
     "@iconify/tools/pathe": ["pathe@1.1.2", "", {}, "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ=="],
 
     "@iconify/tools/svgo": ["svgo@3.3.2", "", { "dependencies": { "@trysound/sax": "0.2.0", "commander": "^7.2.0", "css-select": "^5.1.0", "css-tree": "^2.3.1", "css-what": "^6.1.0", "csso": "^5.0.5", "picocolors": "^1.0.0" }, "bin": "./bin/svgo" }, "sha512-OoohrmuUlBs8B8o6MB2Aevn+pRIH9zDALSR+6hhqVfa6fRwG/Qw9VUMSMW9VNg2CFc/MTIfabtdOVl9ODIJjpw=="],
@@ -1508,6 +1569,8 @@
     "@rollup/pluginutils/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
     "@shikijs/core/hast-util-to-html": ["hast-util-to-html@9.0.5", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "ccount": "^2.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-whitespace": "^3.0.0", "html-void-elements": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "stringify-entities": "^4.0.0", "zwitch": "^2.0.4" } }, "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw=="],
+
+    "@svgr/hast-util-to-babel-ast/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
     "@tailwindcss/node/lightningcss": ["lightningcss@1.31.1", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.31.1", "lightningcss-darwin-arm64": "1.31.1", "lightningcss-darwin-x64": "1.31.1", "lightningcss-freebsd-x64": "1.31.1", "lightningcss-linux-arm-gnueabihf": "1.31.1", "lightningcss-linux-arm64-gnu": "1.31.1", "lightningcss-linux-arm64-musl": "1.31.1", "lightningcss-linux-x64-gnu": "1.31.1", "lightningcss-linux-x64-musl": "1.31.1", "lightningcss-win32-arm64-msvc": "1.31.1", "lightningcss-win32-x64-msvc": "1.31.1" } }, "sha512-l51N2r93WmGUye3WuFoN5k10zyvrVs0qfKBhyC5ogUQ6Ew6JUSswh78mbSO+IU3nTWsyOArqPCcShdQSadghBQ=="],
 
@@ -1535,7 +1598,13 @@
 
     "@types/babel__traverse/@babel/types": ["@babel/types@7.26.9", "", { "dependencies": { "@babel/helper-string-parser": "^7.25.9", "@babel/helper-validator-identifier": "^7.25.9" } }, "sha512-Y3IR1cRnOxOCDvMmNiym7XpXQ93iGDDPHx+Zj+NM+rg0fBaShfQLkg+hKPaZCEvg5N/LeCo4+Rj/i3FuJsIQaw=="],
 
+    "@types/sax/@types/node": ["@types/node@17.0.45", "", {}, "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw=="],
+
+    "@types/tar/@types/node": ["@types/node@17.0.45", "", {}, "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw=="],
+
     "@types/tar/minipass": ["minipass@4.2.8", "", {}, "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ=="],
+
+    "@types/yauzl/@types/node": ["@types/node@17.0.45", "", {}, "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw=="],
 
     "@vscode/emmet-helper/jsonc-parser": ["jsonc-parser@2.3.1", "", {}, "sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg=="],
 
@@ -1543,11 +1612,15 @@
 
     "anymatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
+    "astro/es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
+
     "astro/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "boxen/camelcase": ["camelcase@8.0.0", "", {}, "sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA=="],
 
     "cheerio/undici": ["undici@6.21.1", "", {}, "sha512-q/1rj5D0/zayJB2FraXdaWxbhWiNKDvu8naDT2dl1yTlvJp4BLtOcp2a5BvgGNQpYYJzau7tf1WgKv3b+7mqpQ=="],
+
+    "cheerio/whatwg-mimetype": ["whatwg-mimetype@4.0.0", "", {}, "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg=="],
 
     "cliui/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
@@ -1557,9 +1630,13 @@
 
     "csso/css-tree": ["css-tree@2.2.1", "", { "dependencies": { "mdn-data": "2.0.28", "source-map-js": "^1.0.1" } }, "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA=="],
 
+    "dom-serializer/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+
     "extract-zip/debug": ["debug@4.4.0", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA=="],
 
     "fs-minipass/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
+
+    "htmlparser2/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
     "lightningcss/detect-libc": ["detect-libc@2.0.3", "", {}, "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw=="],
 
@@ -1569,6 +1646,8 @@
 
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
+    "miniflare/ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
+
     "minizlib/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
 
     "mlly/acorn": ["acorn@8.14.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA=="],
@@ -1577,13 +1656,17 @@
 
     "ofetch/ufo": ["ufo@1.6.1", "", {}, "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA=="],
 
+    "parse5/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+
+    "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
+
     "prettier-plugin-astro/@astrojs/compiler": ["@astrojs/compiler@2.10.4", "", {}, "sha512-86B3QGagP99MvSNwuJGiYSBHnh8nLvm2Q1IFI15wIUJJsPeQTO3eb2uwBmrqRsXykeR/mBzH8XCgz5AAt1BJrQ=="],
+
+    "protobufjs/@types/node": ["@types/node@17.0.45", "", {}, "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw=="],
 
     "rimraf/glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
 
     "rollup/@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
-
-    "sitemap/@types/node": ["@types/node@24.12.0", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ=="],
 
     "string-width-cjs/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
@@ -1818,6 +1901,8 @@
     "@astrojs/cloudflare/wrangler/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.0", "", { "os": "win32", "cpu": "x64" }, "sha512-aIitBcjQeyOhMTImhLZmtxfdOcuNRpwlPNmlFKPcHQYPhEssw75Cl1TSXJXpMkzaua9FUetx/4OQKq7eJul5Cg=="],
 
     "@astrojs/cloudflare/wrangler/miniflare/undici": ["undici@7.14.0", "", {}, "sha512-Vqs8HTzjpQXZeXdpsfChQTlafcMQaaIwnGwLam1wudSSjlJeQ3bw1j+TLPePgrCnCpUXx7Ba5Pdpf5OBih62NQ=="],
+
+    "@astrojs/cloudflare/wrangler/miniflare/ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
 
     "@astrojs/cloudflare/wrangler/miniflare/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,10 @@
     "astro": "astro",
     "check": "ultracite check",
     "fix": "ultracite fix",
+    "test": "bun run test:unit && bun run test:e2e",
+    "test:unit": "vitest run",
+    "test:unit:watch": "vitest",
+    "test:e2e": "playwright test",
     "prepare": "husky",
     "deploy": "astro build && wrangler pages deploy",
     "cf-typegen": "wrangler types"
@@ -35,10 +39,13 @@
   "devDependencies": {
     "@biomejs/biome": "2.3.11",
     "@iconify-json/mdi": "^1.2.3",
+    "@playwright/test": "^1.60.0",
     "@tailwindcss/typography": "^0.5.19",
+    "happy-dom": "^20.10.2",
     "husky": "^9.1.7",
     "ultracite": "7.0.12",
     "vite-plugin-svgr": "^4.5.0",
+    "vitest": "^4.1.8",
     "wrangler": "^4.72.0"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./test/e2e",
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  reporter: process.env.CI ? [["github"], ["html", { open: "never" }]] : "list",
+  use: {
+    baseURL: "http://localhost:4321",
+    trace: "on-first-retry",
+    // Frontmatter dates are midnight UTC; NotesApp formats them in the
+    // browser's timezone. Pin UTC so date assertions are deterministic.
+    timezoneId: "UTC",
+  },
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+  webServer: {
+    command: "bun run dev",
+    url: "http://localhost:4321",
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    env: {
+      PLAYWRIGHT_TEST: "1",
+      GOOGLE_API_KEY: process.env.GOOGLE_API_KEY ?? "test-dummy-key",
+      // Every dev request shares the "unknown" client IP, so the suite would
+      // rate-limit itself with the production default.
+      RATE_LIMITER_MAX_REQUESTS_PER_WINDOW: "100000",
+    },
+  },
+});

--- a/src/components/dock.tsx
+++ b/src/components/dock.tsx
@@ -16,7 +16,10 @@ export default function Dock({
   openWindowIds,
 }: Props): React.ReactElement {
   return (
-    <div className="fixed bottom-0 left-1/2 z-50 -translate-x-1/2 pb-4">
+    <div
+      className="fixed bottom-0 left-1/2 z-50 -translate-x-1/2 pb-4"
+      data-testid="dock"
+    >
       <div className="flex items-end gap-2 rounded-2xl bg-white/10 px-2 pt-2 pb-2 backdrop-blur-2xl">
         {apps.map((app) => {
           const Icon = app.icon;

--- a/src/content/blog-schema.ts
+++ b/src/content/blog-schema.ts
@@ -1,0 +1,11 @@
+import { z } from "astro/zod";
+
+export const blogSchema = z.object({
+  title: z.string(),
+  date: z.date(),
+  preview: z.string(),
+  tags: z.array(z.string()).default([]),
+  draft: z.boolean().default(false),
+});
+
+export type BlogFrontmatter = z.infer<typeof blogSchema>;

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -1,14 +1,9 @@
-import { defineCollection, z } from "astro:content";
+import { defineCollection } from "astro:content";
+import { blogSchema } from "./blog-schema";
 
 const blog = defineCollection({
   type: "content",
-  schema: z.object({
-    title: z.string(),
-    date: z.date(),
-    preview: z.string(),
-    tags: z.array(z.string()).default([]),
-    draft: z.boolean().default(false),
-  }),
+  schema: blogSchema,
 });
 
 export const collections = { blog };

--- a/src/middleware/cors.ts
+++ b/src/middleware/cors.ts
@@ -53,8 +53,11 @@ export const corsMiddleware = defineMiddleware(async (context, next) => {
     "Origin, X-Requested-With, Content-Type, Accept"
   );
 
+  // Response properties live on the prototype, so spreading the response
+  // would drop them and reset every status to 200.
   return new Response(response.body, {
-    ...response,
+    status: response.status,
+    statusText: response.statusText,
     headers,
   });
 });

--- a/src/middleware/rate-limitter.ts
+++ b/src/middleware/rate-limitter.ts
@@ -85,9 +85,9 @@ let rateLimiter: RateLimiter | null = null;
 /**
  * Middleware for rate limiting API requests.
  *
- * This middleware implements rate limiting functionality for API endpoints using both client ID and IP address
- * for identification. It tracks request counts within configured time windows and enforces rate limits
- * by returning 429 status codes when limits are exceeded.
+ * This middleware implements rate limiting functionality for API endpoints keyed
+ * by client IP address. It tracks request counts within configured time windows
+ * and enforces rate limits by returning 429 status codes when limits are exceeded.
  *
  * @param context - The middleware context containing the request object
  * @param next - The function to call the next middleware in the chain
@@ -119,18 +119,15 @@ export const rateLimiterMiddleware = defineMiddleware(async (context, next) => {
     return next();
   }
 
-  // Use both client ID and IP for more robust rate limiting
-  const clientId = request.headers.get("X-Client-ID");
+  // Key rate limits by IP only: keying on the client-supplied X-Client-ID
+  // would let callers reset their bucket by rotating the header.
   const clientIP =
     request.headers.get("CF-Connecting-IP") ||
     request.headers.get("X-Forwarded-For") ||
     request.headers.get("X-Real-IP") ||
     "unknown";
 
-  // Combine both identifiers for better rate limiting
-  const identifier = clientId ? `${clientId}-${clientIP}` : clientIP;
-
-  console.log(`Rate limiting request from: ${identifier}`);
+  console.log(`Rate limiting request from: ${clientIP}`);
 
   // Check rate limit
   const isLimited = rateLimiter.isRateLimited(clientIP);

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -27,7 +27,7 @@ const sortedPosts = blogPosts.sort(
 
 // Prepare posts metadata for client (content will be hydrated from hidden divs)
 const postsForClient = sortedPosts.map((post) => ({
-  slug: post.id,
+  slug: post.slug,
   title: post.data.title,
   date: post.data.date.toISOString(),
   preview: post.data.preview,
@@ -44,7 +44,7 @@ const postsForClient = sortedPosts.map((post) => ({
     {sortedPosts.map(async (post) => {
       const { Content } = await render(post);
       return (
-        <div data-slug={post.id}>
+        <div data-slug={post.slug}>
           <Content />
         </div>
       );

--- a/test/e2e/api.spec.ts
+++ b/test/e2e/api.spec.ts
@@ -1,0 +1,56 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("api surface", () => {
+  test("gemini endpoint rejects a malformed body with a JSON error", async ({
+    request,
+  }) => {
+    // A non-JSON body fails parsing inside the route regardless of whether a
+    // real API key is configured, so this is deterministic locally and in CI.
+    const response = await request.post("/api/llm/gemini", {
+      headers: { "Content-Type": "application/json" },
+      data: "not-json",
+    });
+
+    expect(response.status()).toBeGreaterThanOrEqual(400);
+    expect(response.headers()["content-type"]).toContain("application/json");
+
+    const body = (await response.json()) as { error?: string };
+    expect(typeof body.error).toBe("string");
+
+    expect(response.headers()["x-ratelimit-remaining"]).toBeDefined();
+    expect(response.headers()["x-ratelimit-reset"]).toBeDefined();
+    expect(response.headers()["retry-after"]).toBeDefined();
+  });
+
+  test("gemini endpoint answers CORS preflight", async ({ request }) => {
+    // In dev, Vite answers OPTIONS preflights before our middleware runs, so
+    // only assert that a browser would be allowed to POST. The middleware's
+    // exact headers are pinned by test/unit/cors.test.ts.
+    const response = await request.fetch("/api/llm/gemini", {
+      method: "OPTIONS",
+      headers: {
+        Origin: "http://localhost:4321",
+        "Access-Control-Request-Method": "POST",
+        "Access-Control-Request-Headers": "Content-Type",
+      },
+    });
+
+    expect(response.status()).toBeLessThan(400);
+    const headers = response.headers();
+    expect(headers["access-control-allow-origin"]).toBeDefined();
+    expect(headers["access-control-allow-methods"]).toContain("POST");
+  });
+
+  test("robots.txt disallows the api and points at the sitemap", async ({
+    request,
+  }) => {
+    const response = await request.get("/robots.txt");
+    expect(response.status()).toBe(200);
+
+    const body = await response.text();
+    expect(body).toContain("Disallow: /api/*");
+    expect(body).toContain(
+      "Sitemap: https://edwardvaisman.ca/sitemap-index.xml"
+    );
+  });
+});

--- a/test/e2e/desktop.spec.ts
+++ b/test/e2e/desktop.spec.ts
@@ -1,0 +1,57 @@
+import { expect, test } from "@playwright/test";
+
+const NOTES_LABEL = /^Notes$/;
+
+test.describe("desktop", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+  });
+
+  test("opens the terminal window on load", async ({ page }) => {
+    await expect(
+      page.getByText("Ghostty Terminal - edwardvaisman.ca")
+    ).toBeVisible();
+  });
+
+  test("renders the dock with link apps pointing at the right targets", async ({
+    page,
+  }) => {
+    const dock = page.getByTestId("dock");
+
+    await expect(dock.locator("a")).toHaveCount(4);
+    await expect(dock.locator("button")).toHaveCount(2);
+
+    await expect(
+      dock.locator('a[href="mailto:vaismanedward@gmail.com"]')
+    ).toHaveAttribute("rel", "noopener noreferrer");
+    await expect(
+      dock.locator('a[href="https://github.com/eddyv"]')
+    ).toHaveAttribute("target", "_blank");
+    await expect(
+      dock.locator('a[href="https://www.linkedin.com/in/edwardvaisman/"]')
+    ).toHaveAttribute("rel", "noopener noreferrer");
+    await expect(dock.locator('a[href$="cv.pdf"]')).toBeVisible();
+  });
+
+  test("toggles the Notes window from the dock", async ({ page }) => {
+    const dock = page.getByTestId("dock");
+    const notesDockButton = dock.locator("button", {
+      has: page.locator("span", { hasText: NOTES_LABEL }),
+    });
+    // Closed windows stay mounted at opacity-0; aria-hidden tracks open state.
+    const notesWindow = page
+      .locator("div[aria-hidden]")
+      .filter({ has: page.locator("article") });
+
+    await expect(notesWindow).toHaveAttribute("aria-hidden", "true");
+
+    await notesDockButton.click();
+    await expect(notesWindow).toHaveAttribute("aria-hidden", "false");
+
+    await notesWindow.locator('button[aria-label="Close window"]').click();
+    await expect(notesWindow).toHaveAttribute("aria-hidden", "true");
+
+    await notesDockButton.click();
+    await expect(notesWindow).toHaveAttribute("aria-hidden", "false");
+  });
+});

--- a/test/e2e/home.spec.ts
+++ b/test/e2e/home.spec.ts
@@ -1,0 +1,54 @@
+import { expect, test } from "@playwright/test";
+import { expectedPosts } from "../fixtures/expected-posts";
+
+const DESCRIPTION_PATTERN = /Software Engineer based in Toronto/;
+
+test.describe("home page", () => {
+  test("serves the page with SEO metadata", async ({ page }) => {
+    const response = await page.goto("/");
+    expect(response?.status()).toBe(200);
+
+    await expect(page).toHaveTitle("Edward Vaisman - Software Engineer");
+    await expect(page.locator('meta[name="description"]')).toHaveAttribute(
+      "content",
+      DESCRIPTION_PATTERN
+    );
+    await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
+      "href",
+      "https://edwardvaisman.ca"
+    );
+    await expect(page.locator('meta[property="og:title"]')).toHaveAttribute(
+      "content",
+      "Edward Vaisman - Software Engineer"
+    );
+    // The sitemap file itself only exists in build output; dev serves the tag.
+    await expect(page.locator('link[rel="sitemap"]')).toHaveAttribute(
+      "href",
+      "/sitemap-index.xml"
+    );
+  });
+
+  test("embeds both blog posts in the content store, newest first", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    const store = page.locator("#blog-content-store > [data-slug]");
+    await expect(store).toHaveCount(expectedPosts.length);
+
+    const slugs = await store.evaluateAll((divs) =>
+      divs.map((div) => div.getAttribute("data-slug"))
+    );
+    expect(slugs).toEqual(expectedPosts.map((post) => post.slug));
+
+    for (const post of expectedPosts) {
+      const postStore = page.locator(
+        `#blog-content-store > [data-slug="${post.slug}"]`
+      );
+      await expect(postStore.locator("h1")).toContainText(post.h1Fragment);
+      expect(
+        await postStore.locator(`img[src^="${post.imagePathPrefix}"]`).count()
+      ).toBeGreaterThan(0);
+    }
+  });
+});

--- a/test/e2e/notes.spec.ts
+++ b/test/e2e/notes.spec.ts
@@ -1,0 +1,77 @@
+import { expect, test } from "@playwright/test";
+import { expectedPosts } from "../fixtures/expected-posts";
+
+const [newestPost, olderPost] = expectedPosts;
+const NOTES_LABEL = /^Notes$/;
+const YEAR_HEADER_PATTERN = /^(2025|2021)$/;
+
+test.describe("notes app", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+    await page
+      .getByTestId("dock")
+      .locator("button", {
+        has: page.locator("span", { hasText: NOTES_LABEL }),
+      })
+      .click();
+  });
+
+  test("lists both posts grouped by year, newest first", async ({ page }) => {
+    await expect(
+      page.getByRole("button", { name: newestPost.title })
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: olderPost.title })
+    ).toBeVisible();
+
+    // Year group headers, newest year first.
+    const yearHeaders = page.locator("span", {
+      hasText: YEAR_HEADER_PATTERN,
+    });
+    await expect(yearHeaders.first()).toHaveText(String(newestPost.year));
+    await expect(yearHeaders.last()).toHaveText(String(olderPost.year));
+  });
+
+  test("hydrates and renders the newest post by default", async ({ page }) => {
+    const article = page.locator("article");
+    await expect(article).toBeVisible();
+
+    // Server-side `content` is empty - a populated article proves the
+    // blog-content-loaded hydration handshake worked.
+    await expect(article.locator("h1")).toContainText(newestPost.h1Fragment);
+    await expect(
+      article.locator("h2", { hasText: newestPost.expectedHeading })
+    ).toBeVisible();
+    await expect(page.getByText(newestPost.formattedDate)).toBeVisible();
+
+    const image = article
+      .locator(`img[src^="${newestPost.imagePathPrefix}"]`)
+      .first();
+    await image.scrollIntoViewIfNeeded();
+    await expect(image).toBeVisible();
+    // Poll: naturalWidth is 0 until the browser has fetched the image bytes.
+    await expect
+      .poll(() => image.evaluate((img: HTMLImageElement) => img.naturalWidth))
+      .toBeGreaterThan(0);
+  });
+
+  test("switches to the older post on selection", async ({ page }) => {
+    await page.locator("button", { hasText: olderPost.title }).click();
+
+    const article = page.locator("article");
+    await expect(article.locator("h1")).toContainText(olderPost.h1Fragment);
+    await expect(
+      article.locator("h2", { hasText: olderPost.expectedHeading })
+    ).toBeVisible();
+    await expect(page.getByText(olderPost.formattedDate)).toBeVisible();
+
+    const image = article
+      .locator(`img[src^="${olderPost.imagePathPrefix}"]`)
+      .first();
+    await image.scrollIntoViewIfNeeded();
+    await expect(image).toBeVisible();
+    await expect
+      .poll(() => image.evaluate((img: HTMLImageElement) => img.naturalWidth))
+      .toBeGreaterThan(0);
+  });
+});

--- a/test/fixtures/expected-posts.ts
+++ b/test/fixtures/expected-posts.ts
@@ -1,0 +1,31 @@
+/**
+ * The cross-phase content contract.
+ *
+ * These values pin the user-visible blog behavior (slugs, titles, ordering,
+ * headings, images) so the Astro 6 upgrade and the EmDash migration can prove
+ * they introduced no regressions. Posts are listed in expected display order
+ * (date descending).
+ */
+export const expectedPosts = [
+  {
+    slug: "ai-agents-anthropic-mcp-confluent",
+    title:
+      "Powering AI Agents with Real-Time Data Using Anthropic's MCP and Confluent",
+    // Rendered markdown applies smartypants (straight quote -> curly), so
+    // in-content h1 assertions use an apostrophe-free fragment.
+    h1Fragment: "Powering AI Agents with Real-Time Data",
+    year: 2025,
+    formattedDate: "March 25, 2025",
+    imagePathPrefix: "/blog/ai-agents-anthropic-mcp/",
+    expectedHeading: "What Is Model Context Protocol?",
+  },
+  {
+    slug: "deciding-to-become-event-driven-enterprise",
+    title: "Deciding to Become an Event Driven Enterprise",
+    h1Fragment: "Deciding to Become an Event Driven Enterprise",
+    year: 2021,
+    formattedDate: "August 23, 2021",
+    imagePathPrefix: "/blog/event-driven-enterprise/",
+    expectedHeading: "EDA - A definition",
+  },
+] as const;

--- a/test/unit/blog-schema.test.ts
+++ b/test/unit/blog-schema.test.ts
@@ -1,0 +1,61 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { blogSchema } from "../../src/content/blog-schema";
+import { expectedPosts } from "../fixtures/expected-posts";
+
+const MD_EXTENSION = /\.md$/;
+
+const validFrontmatter = {
+  title: "A Post",
+  date: new Date("2025-03-25"),
+  preview: "A preview",
+  tags: ["tag-one"],
+  draft: false,
+};
+
+describe("blogSchema", () => {
+  it("parses valid frontmatter", () => {
+    const parsed = blogSchema.parse(validFrontmatter);
+    expect(parsed.title).toBe("A Post");
+    expect(parsed.date).toEqual(new Date("2025-03-25"));
+    expect(parsed.tags).toEqual(["tag-one"]);
+  });
+
+  it("defaults tags to an empty array", () => {
+    const { tags: _tags, ...withoutTags } = validFrontmatter;
+    const parsed = blogSchema.parse(withoutTags);
+    expect(parsed.tags).toEqual([]);
+  });
+
+  it("defaults draft to false", () => {
+    const { draft: _draft, ...withoutDraft } = validFrontmatter;
+    const parsed = blogSchema.parse(withoutDraft);
+    expect(parsed.draft).toBe(false);
+  });
+
+  it("rejects frontmatter without a title", () => {
+    const { title: _title, ...withoutTitle } = validFrontmatter;
+    expect(() => blogSchema.parse(withoutTitle)).toThrow();
+  });
+
+  it("rejects a non-date date", () => {
+    expect(() =>
+      blogSchema.parse({ ...validFrontmatter, date: "2025-03-25" })
+    ).toThrow();
+  });
+});
+
+describe("blog content contract", () => {
+  it("post files match the expected slugs in the content directory", () => {
+    const blogDir = path.join(process.cwd(), "src/content/blog");
+    const slugs = fs
+      .readdirSync(blogDir)
+      .filter((file) => file.endsWith(".md"))
+      .map((file) => file.replace(MD_EXTENSION, ""))
+      .sort();
+
+    const expectedSlugs = expectedPosts.map((post) => post.slug).sort();
+    expect(slugs).toEqual(expectedSlugs);
+  });
+});

--- a/test/unit/cors.test.ts
+++ b/test/unit/cors.test.ts
@@ -1,0 +1,80 @@
+import type { APIContext, MiddlewareNext } from "astro";
+import { describe, expect, it, vi } from "vitest";
+import { expectResponse } from "./helpers";
+
+vi.mock("astro:middleware", () => ({
+  defineMiddleware: (fn: unknown) => fn,
+}));
+
+const createContext = (method: string, headers?: Record<string, string>) =>
+  ({
+    request: new Request("https://edwardvaisman.ca/api/llm/gemini", {
+      method,
+      headers,
+    }),
+    site: new URL("https://edwardvaisman.ca"),
+  }) as unknown as APIContext;
+
+describe("corsMiddleware", () => {
+  it("answers preflight OPTIONS requests without calling next", async () => {
+    const { corsMiddleware } = await import("../../src/middleware/cors");
+    const next = vi.fn() as unknown as MiddlewareNext;
+
+    const response = expectResponse(
+      await corsMiddleware(
+        createContext("OPTIONS", { Origin: "https://edwardvaisman.ca" }),
+        next
+      )
+    );
+
+    expect(next).not.toHaveBeenCalled();
+    expect(response.headers.get("Access-Control-Allow-Methods")).toBe(
+      "GET,HEAD,OPTIONS,POST,PUT"
+    );
+    expect(response.headers.get("Access-Control-Allow-Headers")).toBe(
+      "Origin, X-Requested-With, Content-Type, Accept"
+    );
+    expect(response.body).toBeNull();
+  });
+
+  it("appends CORS headers and preserves downstream status", async () => {
+    const { corsMiddleware } = await import("../../src/middleware/cors");
+    const next = vi.fn(() =>
+      Promise.resolve(
+        new Response("payload", {
+          status: 201,
+          headers: { "X-Existing": "yes" },
+        })
+      )
+    ) as unknown as MiddlewareNext;
+
+    const response = expectResponse(
+      await corsMiddleware(
+        createContext("GET", { Origin: "https://edwardvaisman.ca" }),
+        next
+      )
+    );
+
+    expect(next).toHaveBeenCalledOnce();
+    expect(response.status).toBe(201);
+    expect(response.headers.get("X-Existing")).toBe("yes");
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBeTruthy();
+    expect(await response.text()).toBe("payload");
+  });
+
+  it("echoes the request origin in dev mode", async () => {
+    // Vitest runs with import.meta.env.DEV === true, exercising the dev branch.
+    const { corsMiddleware } = await import("../../src/middleware/cors");
+
+    const response = expectResponse(
+      await corsMiddleware(
+        createContext("OPTIONS", { Origin: "http://localhost:4321" }),
+        vi.fn() as unknown as MiddlewareNext
+      )
+    );
+
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBe(
+      "http://localhost:4321"
+    );
+  });
+});

--- a/test/unit/create-terminal-commands.test.ts
+++ b/test/unit/create-terminal-commands.test.ts
@@ -1,0 +1,105 @@
+// @vitest-environment happy-dom
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createTerminalCommands } from "../../src/utils/create-terminal-commands";
+
+describe("createTerminalCommands", () => {
+  const setHistory = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+  });
+
+  it("registers the four commands", () => {
+    const commands = createTerminalCommands({ setHistory });
+    expect(Object.keys(commands).sort()).toEqual([
+      "/ai",
+      "/clear",
+      "/help",
+      "/whoami",
+    ]);
+  });
+
+  it("lists every command in the help output", () => {
+    const commands = createTerminalCommands({ setHistory });
+    const help = commands["/help"].handle() as string;
+
+    for (const name of ["/help", "/clear", "/ai", "/whoami"]) {
+      expect(help).toContain(name);
+    }
+  });
+
+  it("shows detailed help for a specific command", () => {
+    const commands = createTerminalCommands({ setHistory });
+    const help = commands["/help"].handle(["whoami"]) as string;
+    expect(help).toContain("/whoami - Display information about Edward");
+  });
+
+  it("reports unknown commands in help", () => {
+    const commands = createTerminalCommands({ setHistory });
+    const help = commands["/help"].handle(["bogus"]) as string;
+    expect(help).toContain("Command not found: bogus");
+  });
+
+  it("clears history via /clear", () => {
+    const commands = createTerminalCommands({ setHistory });
+    const output = commands["/clear"].handle();
+    expect(setHistory).toHaveBeenCalledWith([]);
+    expect(output).toBe("");
+  });
+
+  it("describes Edward via /whoami", () => {
+    const commands = createTerminalCommands({ setHistory });
+    const output = commands["/whoami"].handle() as string;
+    expect(output).toContain("Edward Vaisman");
+    expect(output).toContain("vaismanedward@gmail.com");
+  });
+
+  it("requires a question for /ai", async () => {
+    const commands = createTerminalCommands({ setHistory });
+    const output = await commands["/ai"].handle([]);
+    expect(output).toContain("Please provide a question");
+  });
+
+  it("returns the LLM response for /ai", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() =>
+        Promise.resolve(Response.json({ response: "I am an answer" }))
+      )
+    );
+
+    const commands = createTerminalCommands({ setHistory });
+    const output = await commands["/ai"].handle(["hello", "there"]);
+    expect(output).toBe("I am an answer");
+
+    const fetchMock = fetch as unknown as ReturnType<typeof vi.fn>;
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/api/llm/gemini");
+    expect(JSON.parse(init.body as string)).toEqual({
+      message: "hello there",
+    });
+  });
+
+  it("surfaces API errors for /ai", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.resolve(Response.json({ error: "nope" })))
+    );
+
+    const commands = createTerminalCommands({ setHistory });
+    const output = await commands["/ai"].handle(["hello"]);
+    expect(output).toBe("Error: nope");
+  });
+
+  it("falls back gracefully when fetch rejects", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.reject(new Error("network down")))
+    );
+
+    const commands = createTerminalCommands({ setHistory });
+    const output = await commands["/ai"].handle(["hello"]);
+    expect(output).toBe("Sorry, there was an error processing your request.");
+  });
+});

--- a/test/unit/generate-client-id.test.ts
+++ b/test/unit/generate-client-id.test.ts
@@ -1,0 +1,29 @@
+// @vitest-environment happy-dom
+import { beforeEach, describe, expect, it } from "vitest";
+import { generateClientId } from "../../src/utils/generate-client-id";
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+describe("generateClientId", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("returns an existing client id from localStorage", () => {
+    localStorage.setItem("clientId", "existing-id");
+    expect(generateClientId()).toBe("existing-id");
+  });
+
+  it("generates and persists a UUID when none exists", () => {
+    const id = generateClientId();
+    expect(id).toMatch(UUID_PATTERN);
+    expect(localStorage.getItem("clientId")).toBe(id);
+  });
+
+  it("returns the same id on subsequent calls", () => {
+    const first = generateClientId();
+    const second = generateClientId();
+    expect(second).toBe(first);
+  });
+});

--- a/test/unit/helpers.ts
+++ b/test/unit/helpers.ts
@@ -1,0 +1,10 @@
+/**
+ * Middleware handlers are typed to return `Promise<void | Response>`.
+ * Narrow to a concrete Response so assertions typecheck.
+ */
+export function expectResponse(value: unknown): Response {
+  if (!(value instanceof Response)) {
+    throw new Error("Expected middleware to return a Response");
+  }
+  return value;
+}

--- a/test/unit/rate-limiter.test.ts
+++ b/test/unit/rate-limiter.test.ts
@@ -1,0 +1,140 @@
+import type { APIContext, MiddlewareNext } from "astro";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { expectResponse } from "./helpers";
+
+vi.mock("astro:env/server", () => ({
+  RATE_LIMITER_WINDOW_MS: 1000,
+  RATE_LIMITER_MAX_REQUESTS_PER_WINDOW: 3,
+}));
+
+vi.mock("astro:middleware", () => ({
+  defineMiddleware: (fn: unknown) => fn,
+}));
+
+const importRateLimiterModule = async () => {
+  vi.resetModules();
+  return await import("../../src/middleware/rate-limitter");
+};
+
+const createContext = (url: string, headers?: Record<string, string>) =>
+  ({
+    request: new Request(url, { headers }),
+  }) as unknown as APIContext;
+
+const passthroughNext = (() =>
+  Promise.resolve(new Response("ok", { status: 200 }))) as MiddlewareNext;
+
+describe("RateLimiter", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("does not limit requests under the maximum", async () => {
+    const { RateLimiter } = await importRateLimiterModule();
+    const limiter = new RateLimiter({ windowMs: 1000, maxRequests: 3 });
+
+    expect(limiter.isRateLimited("client-a")).toBe(false);
+    expect(limiter.isRateLimited("client-a")).toBe(false);
+    expect(limiter.isRateLimited("client-a")).toBe(false);
+  });
+
+  it("limits requests over the maximum within a window", async () => {
+    const { RateLimiter } = await importRateLimiterModule();
+    const limiter = new RateLimiter({ windowMs: 1000, maxRequests: 3 });
+
+    limiter.isRateLimited("client-a");
+    limiter.isRateLimited("client-a");
+    limiter.isRateLimited("client-a");
+    expect(limiter.isRateLimited("client-a")).toBe(true);
+  });
+
+  it("resets the limit after the window expires", async () => {
+    const { RateLimiter } = await importRateLimiterModule();
+    const limiter = new RateLimiter({ windowMs: 1000, maxRequests: 1 });
+
+    limiter.isRateLimited("client-a");
+    expect(limiter.isRateLimited("client-a")).toBe(true);
+
+    vi.advanceTimersByTime(1001);
+    expect(limiter.isRateLimited("client-a")).toBe(false);
+  });
+
+  it("tracks identifiers independently", async () => {
+    const { RateLimiter } = await importRateLimiterModule();
+    const limiter = new RateLimiter({ windowMs: 1000, maxRequests: 1 });
+
+    limiter.isRateLimited("client-a");
+    expect(limiter.isRateLimited("client-a")).toBe(true);
+    expect(limiter.isRateLimited("client-b")).toBe(false);
+  });
+
+  it("reports remaining requests", async () => {
+    const { RateLimiter } = await importRateLimiterModule();
+    const limiter = new RateLimiter({ windowMs: 1000, maxRequests: 3 });
+
+    expect(limiter.getRateLimitInfo("client-a").remaining).toBe(3);
+    limiter.isRateLimited("client-a");
+    expect(limiter.getRateLimitInfo("client-a").remaining).toBe(2);
+  });
+});
+
+describe("rateLimiterMiddleware", () => {
+  it("ignores non-api routes", async () => {
+    const { rateLimiterMiddleware } = await importRateLimiterModule();
+    const response = expectResponse(
+      await rateLimiterMiddleware(
+        createContext("https://example.com/"),
+        passthroughNext
+      )
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("X-RateLimit-Remaining")).toBeNull();
+  });
+
+  it("adds rate limit headers to api responses", async () => {
+    const { rateLimiterMiddleware } = await importRateLimiterModule();
+    const response = expectResponse(
+      await rateLimiterMiddleware(
+        createContext("https://example.com/api/llm/gemini", {
+          "CF-Connecting-IP": "10.0.0.1",
+        }),
+        passthroughNext
+      )
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("X-RateLimit-Remaining")).toBe("2");
+    expect(response.headers.get("X-RateLimit-Reset")).toBeTruthy();
+    expect(response.headers.get("Retry-After")).toBeTruthy();
+  });
+
+  it("returns 429 with a JSON body once the limit is exceeded", async () => {
+    const { rateLimiterMiddleware } = await importRateLimiterModule();
+    const context = () =>
+      createContext("https://example.com/api/llm/gemini", {
+        "CF-Connecting-IP": "10.0.0.2",
+      });
+
+    await rateLimiterMiddleware(context(), passthroughNext);
+    await rateLimiterMiddleware(context(), passthroughNext);
+    await rateLimiterMiddleware(context(), passthroughNext);
+    const limited = expectResponse(
+      await rateLimiterMiddleware(context(), passthroughNext)
+    );
+
+    expect(limited.status).toBe(429);
+    expect(limited.headers.get("X-RateLimit-Remaining")).toBe("0");
+
+    const body = (await limited.json()) as {
+      error: string;
+      remainingRequests: number;
+    };
+    expect(body.error).toBe("Rate limit exceeded");
+    expect(body.remainingRequests).toBe(0);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,13 @@
+/// <reference types="vitest/config" />
+import { getViteConfig } from "astro/config";
+
+export default getViteConfig({
+  test: {
+    include: ["test/unit/**/*.test.ts"],
+    environment: "node",
+    env: {
+      // GOOGLE_API_KEY is the only astro:env schema var without a default.
+      GOOGLE_API_KEY: "test-dummy-key",
+    },
+  },
+});


### PR DESCRIPTION
Adds a regression baseline (no test infrastructure existed) ahead of two upcoming migrations: the Astro 5 → 6 upgrade and the move of blog content collections into EmDash. The goal is that both land with these tests passing unchanged, so this PR deliberately pins today's user-visible behavior rather than implementation details.

**What's covered**

- 30 Vitest unit tests: blog frontmatter schema, rate-limiter (class + middleware), CORS middleware, client-id generation, terminal commands. Wired through Astro's `getViteConfig` so `astro:*` virtual modules and tsconfig aliases resolve; middleware tests mock `astro:env/server` for determinism.
- 11 Playwright e2e tests (chromium): SEO tags, the blog content store (2 posts, date-desc order, extension-less slugs), Notes app hydration handshake and post rendering (headings/images by semantics, never HTML snapshots — so shiki/remark internals can change freely), dock links/window toggling, robots.txt, API error semantics + rate-limit headers.
- `test/fixtures/expected-posts.ts` is the shared content contract both migrations must keep green.
- GitHub Actions CI (first workflow in the repo): lint → unit → build → sitemap artifact check → e2e, with Playwright browser caching and dummy `GOOGLE_API_KEY`.

**Three real bugs found while writing the baseline, fixed here with coverage**

1. `cors.ts` spread a `Response` into `ResponseInit`. `Response` properties are prototype getters, so the spread copied nothing and **every non-200 status was flattened to 200 in production** (verified live: the API error path returned 200 with an `{error}` body).
2. The rate limiter computed a combined `X-Client-ID` + IP identifier but only ever keyed by IP. Keying on a client-supplied header would let callers reset their bucket by rotating it, so IP-only is kept deliberately and the dead code removed.
3. `index.astro` keyed the content store by `post.id`, which includes the `.md` extension in legacy collections. Switched to `post.slug` so the DOM contract is identical before and after the Astro 6 glob-loader migration.

**Notes for review**

- The Astro dev toolbar overlaps the dock and intercepts Playwright clicks; it's disabled only when `PLAYWRIGHT_TEST=1` (set by the Playwright webServer).
- e2e dates are pinned with `timezoneId: "UTC"` — frontmatter dates are midnight UTC and the Notes app formats them in browser-local time.
- `bun test` must never be used (bun's runner grabs `*.test.ts` but can't handle `vi.mock`); documented in AGENTS.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)