### PR TITLE
fix(api): harden /api/llm/gemini rate limiting, validation, and error responses

### DIFF
--- a/src/middleware/rate-limitter.ts
+++ b/src/middleware/rate-limitter.ts
@@ -140,17 +140,6 @@ export const rateLimiterMiddleware = defineMiddleware(async (context, next) => {
   const isLimited = rateLimiter.isRateLimited(clientIP);
   const { remaining, resetTime } = rateLimiter.getRateLimitInfo(clientIP);
 
-  // Add rate limit headers to all responses
-  const response = await next();
-  const headers = new Headers(response.headers);
-
-  headers.set("X-RateLimit-Remaining", remaining.toString());
-  headers.set("X-RateLimit-Reset", resetTime?.toString() || "");
-  headers.set(
-    "Retry-After",
-    Math.ceil((resetTime - Date.now()) / 1000).toString()
-  );
-
   if (isLimited) {
     return new Response(
       JSON.stringify({
@@ -169,6 +158,16 @@ export const rateLimiterMiddleware = defineMiddleware(async (context, next) => {
       }
     );
   }
+
+  const response = await next();
+  const headers = new Headers(response.headers);
+
+  headers.set("X-RateLimit-Remaining", remaining.toString());
+  headers.set("X-RateLimit-Reset", resetTime?.toString() || "");
+  headers.set(
+    "Retry-After",
+    Math.ceil((resetTime - Date.now()) / 1000).toString()
+  );
 
   return new Response(response.body, {
     status: response.status,

--- a/src/pages/api/llm/gemini.ts
+++ b/src/pages/api/llm/gemini.ts
@@ -7,14 +7,12 @@ import {
 import { GoogleGenAI } from "@google/genai";
 import type { APIRoute } from "astro";
 
-interface RequestBody {
-  message: string;
-}
-
 export interface AIResponseBody {
   response?: string;
   error?: string;
 }
+
+const MAX_MESSAGE_LENGTH = 2000;
 
 const ai = new GoogleGenAI({ apiKey: GOOGLE_API_KEY });
 /**
@@ -96,8 +94,48 @@ export const POST: APIRoute = async ({
 }: {
   request: Request;
 }): Promise<Response> => {
+  let message: string;
+
   try {
-    const { message }: RequestBody = await request.json();
+    const body: unknown = await request.json();
+    const parsed = body as Record<string, unknown> | null;
+    if (typeof parsed?.message !== "string") {
+      const errorResponse: AIResponseBody = { error: "Invalid request body" };
+      return new Response(JSON.stringify(errorResponse), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    message = parsed.message;
+  } catch {
+    const errorResponse: AIResponseBody = { error: "Invalid request body" };
+    return new Response(JSON.stringify(errorResponse), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  if (message.trim().length === 0) {
+    const errorResponse: AIResponseBody = {
+      error: "Message must not be empty",
+    };
+    return new Response(JSON.stringify(errorResponse), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  if (message.length > MAX_MESSAGE_LENGTH) {
+    const errorResponse: AIResponseBody = {
+      error: "Message must be at most 2000 characters",
+    };
+    return new Response(JSON.stringify(errorResponse), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  try {
     const resumeData: string = await downloadResume(RESUME_URL);
 
     const response = await ai.models.generateContent({
@@ -123,9 +161,10 @@ export const POST: APIRoute = async ({
       },
     });
   } catch (error) {
-    const errorMessage: string =
-      error instanceof Error ? error.message : "An unknown error occurred";
-    const errorResponse: AIResponseBody = { error: errorMessage };
+    console.error("gemini endpoint error:", error);
+    const errorResponse: AIResponseBody = {
+      error: "Sorry, something went wrong while generating a response.",
+    };
     return new Response(JSON.stringify(errorResponse), {
       status: 500,
       headers: {

--- a/test/unit/gemini-route.test.ts
+++ b/test/unit/gemini-route.test.ts
@@ -1,0 +1,138 @@
+import type { APIRoute } from "astro";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("astro:env/server", () => ({
+  GOOGLE_API_KEY: "test-key",
+  GOOGLE_AI_MODEL_ID: "test-model",
+  RESUME_URL: "https://example.com/cv.pdf",
+  RESUME_CACHE_DURATION: 60_000,
+}));
+
+const generateContent = vi.fn();
+vi.mock("@google/genai", () => ({
+  GoogleGenAI: class {
+    models = { generateContent };
+  },
+}));
+
+const importGeminiRoute = async () => {
+  vi.resetModules();
+  return await import("../../src/pages/api/llm/gemini");
+};
+
+const makeRequest = (body: unknown, contentType = "application/json") =>
+  new Request("https://example.com/api/llm/gemini", {
+    method: "POST",
+    headers: { "Content-Type": contentType },
+    body: typeof body === "string" ? body : JSON.stringify(body),
+  });
+
+describe("POST /api/llm/gemini", () => {
+  beforeEach(() => {
+    generateContent.mockReset();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(new ArrayBuffer(8)))
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns 400 for a non-JSON body and does not call generateContent", async () => {
+    const { POST } = await importGeminiRoute();
+    const response = await (POST as APIRoute)({
+      request: new Request("https://example.com/api/llm/gemini", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "not-json",
+      }),
+    } as unknown as Parameters<APIRoute>[0]);
+
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as { error?: string };
+    expect(body.error).toBe("Invalid request body");
+    expect(generateContent).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when message is a non-string (number) and does not call generateContent", async () => {
+    const { POST } = await importGeminiRoute();
+    const response = await (POST as APIRoute)({
+      request: makeRequest({ message: 42 }),
+    } as unknown as Parameters<APIRoute>[0]);
+
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as { error?: string };
+    expect(body.error).toBe("Invalid request body");
+    expect(generateContent).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when message is whitespace-only", async () => {
+    const { POST } = await importGeminiRoute();
+    const response = await (POST as APIRoute)({
+      request: makeRequest({ message: "   " }),
+    } as unknown as Parameters<APIRoute>[0]);
+
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as { error?: string };
+    expect(body.error).toBe("Message must not be empty");
+    expect(generateContent).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when message exceeds 2000 characters", async () => {
+    const { POST } = await importGeminiRoute();
+    const tooLong = "a".repeat(2001);
+    const response = await (POST as APIRoute)({
+      request: makeRequest({ message: tooLong }),
+    } as unknown as Parameters<APIRoute>[0]);
+
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as { error?: string };
+    expect(body.error).toBe("Message must be at most 2000 characters");
+    expect(generateContent).not.toHaveBeenCalled();
+  });
+
+  it("accepts a message of exactly 2000 characters", async () => {
+    const { POST } = await importGeminiRoute();
+    const exactLength = "a".repeat(2000);
+    generateContent.mockResolvedValueOnce({ text: "ok" });
+
+    const response = await (POST as APIRoute)({
+      request: makeRequest({ message: exactLength }),
+    } as unknown as Parameters<APIRoute>[0]);
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { response?: string };
+    expect(body.response).toBe("ok");
+  });
+
+  it("returns 200 with response text for a valid message", async () => {
+    const { POST } = await importGeminiRoute();
+    generateContent.mockResolvedValueOnce({ text: "hi" });
+
+    const response = await (POST as APIRoute)({
+      request: makeRequest({ message: "Tell me about Edward" }),
+    } as unknown as Parameters<APIRoute>[0]);
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { response?: string };
+    expect(body.response).toBe("hi");
+  });
+
+  it("returns 500 without internal details when generateContent rejects", async () => {
+    const { POST } = await importGeminiRoute();
+    generateContent.mockRejectedValueOnce(new Error("internal quota detail"));
+
+    const response = await (POST as APIRoute)({
+      request: makeRequest({ message: "Tell me about Edward" }),
+    } as unknown as Parameters<APIRoute>[0]);
+
+    expect(response.status).toBe(500);
+    const body = (await response.json()) as { error?: string };
+    expect(body.error).not.toContain("internal quota detail");
+    expect(body.error).toBe(
+      "Sorry, something went wrong while generating a response."
+    );
+  });
+});

--- a/test/unit/rate-limiter.test.ts
+++ b/test/unit/rate-limiter.test.ts
@@ -113,6 +113,26 @@ describe("rateLimiterMiddleware", () => {
     expect(response.headers.get("Retry-After")).toBeTruthy();
   });
 
+  it("does not invoke next() once the limit is exceeded", async () => {
+    const { rateLimiterMiddleware } = await importRateLimiterModule();
+    const next = vi.fn(passthroughNext);
+    const context = () =>
+      createContext("https://example.com/api/llm/gemini", {
+        "CF-Connecting-IP": "10.0.0.3",
+      });
+
+    await rateLimiterMiddleware(context(), next);
+    await rateLimiterMiddleware(context(), next);
+    await rateLimiterMiddleware(context(), next);
+    expect(next).toHaveBeenCalledTimes(3);
+
+    const limited = expectResponse(
+      await rateLimiterMiddleware(context(), next)
+    );
+    expect(limited.status).toBe(429);
+    expect(next).toHaveBeenCalledTimes(3); // unchanged — the work was skipped
+  });
+
   it("returns 429 with a JSON body once the limit is exceeded", async () => {
     const { rateLimiterMiddleware } = await importRateLimiterModule();
     const context = () =>


### PR DESCRIPTION
Hardens the public `/api/llm/gemini` endpoint, which costs real money per request (each call sends the full resume PDF to Gemini). Three defects fixed:

1. **Rate limiting now happens before the work.** The middleware computed `isRateLimited` but called `await next()` unconditionally — a throttled caller still triggered (and paid for) the Gemini call, and only the response was discarded. The 429 (byte-identical body and headers) is now returned before `next()` runs.

2. **Request bodies are validated.** `message` must be a non-empty string of at most 2000 characters; malformed JSON, non-string values, whitespace-only, and oversized messages get a 400. Previously any JSON value of any size flowed straight into `generateContent` — unbounded token spend per request.

3. **Internal errors no longer reach clients.** The catch block returned `error.message` verbatim (Google API errors can include model IDs and quota detail) and the terminal UI rendered it. Clients now get a generic message; the full error goes to `console.error`, captured by Cloudflare observability.

The `AIResponseBody` response shape is unchanged, so the terminal client needs no changes. New coverage: a regression test asserting `next()` is not invoked once the limit is hit, and `test/unit/gemini-route.test.ts` covering the validation matrix, the 2000-char boundary, and that 500 bodies never contain internal error detail.

Worth knowing for review: the in-memory limiter is still per-isolate on Workers (limits don't aggregate across PoPs) — making it durable via a Cloudflare rate-limiting binding was deliberately deferred. `MAX_MESSAGE_LENGTH` is the cost-control knob if the terminal ever allows longer prompts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)